### PR TITLE
Deploy a new task definition to Amazon ECS

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -64,4 +64,4 @@ jobs:
       - name: Deploy to Amazon ECS task definition
         run: |
           pip install boto3
-          aws --region us-west-1 ecs update-service --cluster streamingservicebot-cluster --service streamingservicebot-service --task-definition  StreamingservicebotInfraStackStreamingServiceBotTaskDef9C5FBEE0 --force-new-deployment
+          aws --region us-west-1 ecs update-service --cluster streamingservicebot-cluster --service streamingservicebot-service --task-definition StreamingservicebotInfraStackStreamingServiceBotTaskDef9C5FBEE0 --force-new-deployment


### PR DESCRIPTION
Updating workflow to deploy a new task definition to Amazon ECS on `push`, copied from https://github.com/ScottBrenner/hqtrackbot/blob/master/.github/workflows/main.yml#L57-L60